### PR TITLE
A more complete calendar with multiple events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In your preferred calendar application, input your iCalendar URL in the followin
 - http://*homeassistant.local:8123*/api/ics/calendar.*holidays*?s=*yourSuperSecret*
 
 ## Known issues
-- UID are sometimes not unique.
+None.
 
 ## Future enhancements
 Your support is welcomed.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In your preferred calendar application, input your iCalendar URL in the followin
 - http://*homeassistant.local:8123*/api/ics/calendar.*holidays*?s=*yourSuperSecret*
 
 ## Known issues
-- Only supplies the first upcoming event.
+- UID are sometimes not unique.
 
 ## Future enhancements
 Your support is welcomed.

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -140,21 +140,21 @@ class iCalendarView(HomeAssistantView):
                 "summary" in e
                 and e["summary"] is not None
             ):
-                response += f"SUMMARY:{escape(e['summary'])}\n"
+                response += f"SUMMARY:{escape(e['summary']).replace('\n', '\n ').rstrip()}\n"
 
             if (
                 "description" in e
                 and e["description"] is not None
             ):
                 response += (
-                    f"DESCRIPTION:{escape(e['description'])}\n"
+                    f"DESCRIPTION:{escape(e['description']).replace('\n', '\n ').rstrip()}\n"
                 )
 
             if (
                 "location" in e
                 and e["location"] is not None
             ):
-                response += f"LOCATION:{escape(e['location'])}\n"
+                response += f"LOCATION:{escape(e['location']).replace('\n', '\n ').rstrip()}\n"
 
             # Finish up this calendar entry
             response += "END:VEVENT\n"

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -104,6 +104,7 @@ class iCalendarView(HomeAssistantView):
         response += "CALSCALE:GREGORIAN\n"
         response += "METHOD:PUBLISH\n"
         response += f"ORGANIZER;CN=\"{escape(self._state.attributes['friendly_name'])}\":MAILTO:{entity_id}@homeassistant.local\n"
+        response += f"NAME:{escape(self._state.attributes['friendly_name'])}\n"
 
         # Generate the variables
         entity_id = escape(entity_id)

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -130,7 +130,12 @@ class iCalendarView(HomeAssistantView):
                 dtstamp = f'{start}T000000'
 
             # Create and hash the UID
-            uid = f"{entity_id}-{start}"
+            if ("summary" in e and e["summary"] is not None):
+                summary = escape(e['summary'])
+            else:
+                summary = None
+
+            uid = f"{entity_id}-{start}-{end}-{summary}"
             uid = hashlib.sha256(uid.encode('utf-8')).hexdigest()
 
             response += "BEGIN:VEVENT\n"
@@ -141,11 +146,8 @@ class iCalendarView(HomeAssistantView):
             response += f"DTEND:{end}\n"
 
             # Add available optional attribuets to the iCalendar response
-            if (
-                "summary" in e
-                and e["summary"] is not None
-            ):
-                response += f"SUMMARY:{escape(e['summary']).replace('\n', '\n ').rstrip()}\n"
+            if summary is not None:
+                response += f"SUMMARY:{summary.replace('\n', '\n ').rstrip()}\n"
 
             if (
                 "description" in e

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -7,6 +7,7 @@ from http import HTTPStatus
 
 from aiohttp import web
 import datetime
+import hashlib
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
@@ -127,7 +128,10 @@ class iCalendarView(HomeAssistantView):
                     e["end"], "%Y-%m-%d"
                 ).strftime("%Y%m%d")
                 dtstamp = f'{start}T000000'
+
+            # Create and hash the UID
             uid = f"{entity_id}-{start}"
+            uid = hashlib.sha256(uid.encode('utf-8')).hexdigest()
 
             response += "BEGIN:VEVENT\n"
 


### PR DESCRIPTION
This PR adds a larger range of events to the iCalendar file. Currently all events between -4 weeks and +52 weeks are added.  Potentially this could be user configurable.
It also fixes a bug with multi-line values (eg, long descriptions).
I've added a friendly calendar name but my test with Google appears to be ignoring it.

There's a minor issue that multiple events with the same start time (or multiple all day events on the same day) will cause non-unique UIDs.