### PR TITLE
Calendar improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,24 @@ In your preferred calendar application, input your iCalendar URL in the followin
 
 ## Additional configuration
 
-You can add colours to specific named events by adding the colours section to your config.  Colours are specified as [named CSS3 colours](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color).  For example, to colour events for your bin calendar, you might use:
+You can add colours to both calendars and specific named events by adding them to your config.
+Colours are specified as [named CSS3 colours](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color).
+For example, to colour events for your bin calendar, you might use:
 
 ```
 icalendar:
   calendars:
     - entity_id: calendar.bins
       secret: yourSuperSecret
+      colour: black
   colours:
     - name: "Recycling"
       colour: green
     - name: "Food waste"
       colour: brown
 ```
+
+This will colour the event "Recycling" as green, "Food waste" as brown and the calendar itself (usually this is used as the default event colour) as black.
 
 ## Known issues
 None.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In your preferred calendar application, input your iCalendar URL in the followin
 - http://*homeassistant.local:8123*/api/ics/calendar.*holidays*?s=*yourSuperSecret*
 
 ## Known issues
-- UID are sometimes not unique.
+None.
 
 ## Future enhancements
 Your support is welcomed.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In your preferred calendar application, input your iCalendar URL in the followin
 - http://*homeassistant.local:8123*/api/ics/calendar.*holidays*?s=*yourSuperSecret*
 
 ## Known issues
-- Only supplies the first upcoming event.
+- UID are sometimes not unique.
 
 ## Future enhancements
 Your support is welcomed.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ Generates an iCalendar (.ics) link that you can use to view your Home Assistant 
 
    ```
    icalendar:
-     secret: yourSuperSecret
+     calendars:
+       - entity_id: calendar.entity_id
+         secret: yourSuperSecret
    ```
-4. Restart Home Assistant
+
+There should be a "calendars" entry for all calendars that need remote access.
+
+5. Restart Home Assistant
 
 ### Manually
 Copy all files in the *custom_components/icalendar* folder to your Home Assistant folder *config/custom_components/icalendar*.
@@ -31,16 +36,18 @@ In your preferred calendar application, input your iCalendar URL in the followin
 
 ## Additional configuration
 
-You can add colours to specific named events by adding the colours section to your config.  For example:
+You can add colours to specific named events by adding the colours section to your config.  Colours are specified as [named CSS3 colours](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color).  For example, to colour events for your bin calendar, you might use:
 
 ```
 icalendar:
-  secret: yourSuperSecret
+  calendars:
+    - entity_id: calendar.bins
+      secret: yourSuperSecret
   colours:
     - name: "Recycling"
       colour: green
-    - name: "Important Event"
-      colour: red
+    - name: "Food waste"
+      colour: brown
 ```
 
 ## Known issues

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ In your preferred calendar application, input your iCalendar URL in the followin
 
 - http://*homeassistant.local:8123*/api/ics/calendar.*holidays*?s=*yourSuperSecret*
 
+## Additional configuration
+
+You can add colours to specific named events by adding the colours section to your config.  For example:
+
+```
+icalendar:
+  secret: yourSuperSecret
+  colours:
+    - name: "Recycling"
+      colour: green
+    - name: "Important Event"
+      colour: red
+```
+
 ## Known issues
 None.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ icalendar:
 This will colour the event "Recycling" as green, "Food waste" as brown and the calendar itself (usually this is used as the default event colour) as black.
 
 ## Known issues
-None.
+- Line length is not restricted to 75 characters
 
 ## Future enhancements
 Your support is welcomed.

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -140,21 +140,21 @@ class iCalendarView(HomeAssistantView):
                 "summary" in e
                 and e["summary"] is not None
             ):
-                response += f"SUMMARY:{escape(e['summary'])}\n"
+                response += f"SUMMARY:{escape(e['summary']).replace('\n', '\n ').rstrip()}\n"
 
             if (
                 "description" in e
                 and e["description"] is not None
             ):
                 response += (
-                    f"DESCRIPTION:{escape(e['description'])}\n"
+                    f"DESCRIPTION:{escape(e['description']).replace('\n', '\n ').rstrip()}\n"
                 )
 
             if (
                 "location" in e
                 and e["location"] is not None
             ):
-                response += f"LOCATION:{escape(e['location'])}\n"
+                response += f"LOCATION:{escape(e['location']).replace('\n', '\n ').rstrip()}\n"
 
             # Finish up this calendar entry
             response += "END:VEVENT\n"

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -104,6 +104,7 @@ class iCalendarView(HomeAssistantView):
         response += "CALSCALE:GREGORIAN\n"
         response += "METHOD:PUBLISH\n"
         response += f"ORGANIZER;CN=\"{escape(self._state.attributes['friendly_name'])}\":MAILTO:{entity_id}@homeassistant.local\n"
+        response += f"NAME:{escape(self._state.attributes['friendly_name'])}\n"
 
         # Generate the variables
         entity_id = escape(entity_id)

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -130,7 +130,12 @@ class iCalendarView(HomeAssistantView):
                 dtstamp = f'{start}T000000'
 
             # Create and hash the UID
-            uid = f"{entity_id}-{start}"
+            if ("summary" in e and e["summary"] is not None):
+                summary = escape(e['summary'])
+            else:
+                summary = None
+
+            uid = f"{entity_id}-{start}-{end}-{summary}"
             uid = hashlib.sha256(uid.encode('utf-8')).hexdigest()
 
             response += "BEGIN:VEVENT\n"
@@ -141,11 +146,8 @@ class iCalendarView(HomeAssistantView):
             response += f"DTEND:{end}\n"
 
             # Add available optional attribuets to the iCalendar response
-            if (
-                "summary" in e
-                and e["summary"] is not None
-            ):
-                response += f"SUMMARY:{escape(e['summary']).replace('\n', '\n ').rstrip()}\n"
+            if summary is not None:
+                response += f"SUMMARY:{summary.replace('\n', '\n ').rstrip()}\n"
 
             if (
                 "description" in e

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -65,10 +65,13 @@ class iCalendarView(HomeAssistantView):
         #   - entity_id: calendar.entity
         #     secret: secretpassword
         valid_calendar = False
+        calendar_colour = None
         for cal in self.calendars:
             if (("entity_id" in cal) and (cal['entity_id'] == entity_id)) and ("secret" in cal):
                 valid_calendar = True
                 secret = cal['secret']
+                if("colour" in cal):
+                    calendar_colour = cal['colour']
                 break
         
         if valid_calendar is not True:
@@ -120,6 +123,8 @@ class iCalendarView(HomeAssistantView):
         response += "METHOD:PUBLISH\n"
         response += f"ORGANIZER;CN=\"{escape(self._state.attributes['friendly_name'])}\":MAILTO:{entity_id}@homeassistant.local\n"
         response += f"NAME:{escape(self._state.attributes['friendly_name'])}\n"
+        if calendar_colour is not None:
+            response += f"COLOR:{calendar_colour}\n"
 
         # Generate the variables
         entity_id = escape(entity_id)

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -7,7 +7,7 @@ from html import escape
 from http import HTTPStatus
 
 from aiohttp import web
-import datetime
+from datetime import datetime, timezone, timedelta
 import hashlib
 
 from homeassistant.components.http import HomeAssistantView
@@ -100,8 +100,8 @@ class iCalendarView(HomeAssistantView):
 
         # Calculate the start and end timeframe for our calendar
         # We output 4 weeks history and 52 weeks into the future
-        start = (datetime.datetime.now() - datetime.timedelta(weeks=4)).strftime("%Y-%m-%d %H:%M:%S")
-        end = (datetime.datetime.now() + datetime.timedelta(weeks=52)).strftime("%Y-%m-%d %H:%M:%S")
+        start = (datetime.now() - timedelta(weeks=4)).strftime("%Y-%m-%d %H:%M:%S")
+        end = (datetime.now() + timedelta(weeks=52)).strftime("%Y-%m-%d %H:%M:%S")
 
         events = await self.hass.services.async_call('calendar', 'get_events',
               { "entity_id": entity_id,
@@ -132,18 +132,14 @@ class iCalendarView(HomeAssistantView):
         # Iterate through all the events
         for e in events:
             try:
-                start = datetime.datetime.strptime(
-                    e["start"], "%Y-%m-%dT%H:%M:%S%z"
-                ).strftime("%Y%m%dT%H%M%SZ")
-                end = datetime.datetime.strptime(
-                    e["end"], "%Y-%m-%dT%H:%M:%S%z"
-                ).strftime("%Y%m%dT%H%M%SZ")
+                start = datetime.fromisoformat(e["start"]).astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+                end = datetime.fromisoformat(e["end"]).astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
                 dtstamp = start
             except:
-                start = datetime.datetime.strptime(
+                start = datetime.strptime(
                     e["start"], "%Y-%m-%d"
                 ).strftime("%Y%m%d")
-                end = datetime.datetime.strptime(
+                end = datetime.strptime(
                     e["end"], "%Y-%m-%d"
                 ).strftime("%Y%m%d")
                 dtstamp = f'{start}T000000'

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -134,10 +134,10 @@ class iCalendarView(HomeAssistantView):
             try:
                 start = datetime.datetime.strptime(
                     e["start"], "%Y-%m-%dT%H:%M:%S%z"
-                ).strftime("%Y%m%dT%H%M%S")
+                ).strftime("%Y%m%dT%H%M%SZ")
                 end = datetime.datetime.strptime(
                     e["end"], "%Y-%m-%dT%H:%M:%S%z"
-                ).strftime("%Y%m%dT%H%M%S")
+                ).strftime("%Y%m%dT%H%M%SZ")
                 dtstamp = start
             except:
                 start = datetime.datetime.strptime(

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -123,6 +123,7 @@ class iCalendarView(HomeAssistantView):
         response += "METHOD:PUBLISH\n"
         response += f"ORGANIZER;CN=\"{escape(self._state.attributes['friendly_name'])}\":MAILTO:{entity_id}@homeassistant.local\n"
         response += f"NAME:{escape(self._state.attributes['friendly_name'])}\n"
+        response += f"X-WR-CALNAME:{escape(self._state.attributes['friendly_name'])}\n"
         if calendar_colour is not None:
             response += f"COLOR:{calendar_colour}\n"
 

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -129,13 +129,13 @@ class iCalendarView(HomeAssistantView):
 
         # Generate the variables
         entity_id = escape(entity_id)
+        dtstamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
         # Iterate through all the events
         for e in events:
             try:
                 start = datetime.fromisoformat(e["start"]).astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
                 end = datetime.fromisoformat(e["end"]).astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-                dtstamp = start
             except:
                 start = datetime.strptime(
                     e["start"], "%Y-%m-%d"
@@ -143,8 +143,7 @@ class iCalendarView(HomeAssistantView):
                 end = datetime.strptime(
                     e["end"], "%Y-%m-%d"
                 ).strftime("%Y%m%d")
-                dtstamp = f'{start}T000000'
-                
+
             # Create and hash the UID
             if ("summary" in e and e["summary"] is not None):
                 summary = escape(e['summary'])

--- a/custom_components/icalendar/__init__.py
+++ b/custom_components/icalendar/__init__.py
@@ -7,6 +7,7 @@ from http import HTTPStatus
 
 from aiohttp import web
 import datetime
+import hashlib
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
@@ -127,7 +128,10 @@ class iCalendarView(HomeAssistantView):
                     e["end"], "%Y-%m-%d"
                 ).strftime("%Y%m%d")
                 dtstamp = f'{start}T000000'
+
+            # Create and hash the UID
             uid = f"{entity_id}-{start}"
+            uid = hashlib.sha256(uid.encode('utf-8')).hexdigest()
 
             response += "BEGIN:VEVENT\n"
 


### PR DESCRIPTION
Supercedes PR #3 

Improvements include:
 - Gets all events between -4 weeks and +52 weeks when creating the calendar
 - Multi-line details are now formatted as per the specification
 - UID now hashed and unique
 - All day and individual events supported
 - Improved security by requiring calendars to be added to the config with a per-calendar secret
   - BREAKING CHANGE: Calendars not in the config will no longer be accessible (see below)
 - Added ability to assign colours to particular events/calendars
 - Added a friendly name to the calendar (although I haven't found a client which uses it yet)


### Breaking change
Calendars need to be individually specified as accessible, with their own password, to improve security.

```
icalendar:
  secret: yourSuperSecret
```

Needs to be modified to:

```
icalendar:
  calendars:
    - entity_id: calendar.entity_id
      secret: yourSuperSecret
```

Multiple calendars can be specified with their own secrets.  If necessary these can be the same but this should be discouraged.

### Colours

I've added this to the README but in short, events can be assigned colours based on their summary.  This is a case sensitive comparison.

Example from the README which works well with the Waste Collection Schedule integration:

```
icalendar:
  calendars:
    - entity_id: calendar.bins
      secret: yourSuperSecret
      colour: black
  colours:
    - name: "Recycling"
      colour: green
    - name: "Food waste"
      colour: brown
```

I've noticed that Google Calendar appears to ignore the per-event colours but ICSx⁵ brings them across fine.
